### PR TITLE
Changed README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,25 +17,28 @@ Compile with `gcc -o mouse_tracker_2 mouse_tracker_2.c -lwinmm -lgdi32` iirc.
 To run on Linux:
 
 1. **List Input Devices**:  
-   First, you need to find the path of the input device (e.g., TrackPoint).  
+   First, you need to find the path of the input device (e.g., TrackPoint).
    - Compile the device listing program:  
-     `gcc -Wall -g -o list_input_devices list_input_devices.c`
-   
+     `g++ -Wall -g -o list_input_devices list_input_devices.c`
+
    - Run the compiled binary with `sudo`:  
      `sudo ./list_input_devices`
-   
+
    - Note the device path of the input device you want to monitor (e.g., for the TrackPoint, it might be `/dev/input/event13`).
 
 2. **Create the Moans Folder**:  
    Create the `moanswav` folder in your project directory and add `1.wav`, `2.wav`, ..., `10.wav` inside it.
 
 3. **Modify the Device Path**:  
-   Modify the `main.c` file in your project to use the device path you found in the previous step (e.g., `/dev/input/event13`).
+   Modify the `linux_nubmoan.c` file in your project to use the device path you found in the previous step (e.g., `/dev/input/event13`).
 
 4. **Compile the Program**:  
    Compile the `linux-nubmoan` program:  
-   `gcc -Wall -g -lm -pthread -o linux-nubmoan main.c`
+   `g++ -Wall -g -lm -pthread -o linux-nubmoan linux_nubmoan.c`
 
-5. **Run the Program**:  
-   Run the program with `sudo` to access input devices:  
-   `sudo ./linux-nubmoan`
+5. **Granting permissions**:  
+   Grant `linux-nubmoan` file permission to read from `/dev/input` without sudo, not including full root access:  
+   `sudo setcap 'cap_dac_read_search,cap_sys_admin+ep' ./linux-nubmoan`
+
+6. **Run the Program**:  
+   `./linux-nubmoan`


### PR DESCRIPTION
Changed README.md file:

1. Replaced main.c file name with linux_nubmoan.c.

2. Replaced gcc with g++, because gcc threw an exception:

/usr/bin/ld: /tmp/cc0JMJcb.o: in the function «calculateIntensity»:
linux_nubmoan.c:22:(.text+0x35): undefined reference to `sqrt'
collect2: error: ld returned 1 exit status

3. Added an item to the instruction to grant the linux-nubmoan file the right to read from /dev/input without full root access.

4. Removed sudo in the «Run the program» point, because running with sudo generated an exception:

aplay: main:834: error opening audio device: Node is offline